### PR TITLE
Split build and release actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
-name: gomodctl
+name: gomodctl build
 on: 
   push:
     branches:
-      - "!*"
-    tags:
-    - "v*.*.*"
+      - "*"
 
 jobs:
 
@@ -19,7 +17,6 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
-      id: go
 
     - name: Linter
       run: |
@@ -35,10 +32,3 @@ jobs:
     - name: Build
       run: |        
         make build
-
-    - name: goreleaser
-      uses: goreleaser/goreleaser-action@master
-      with:
-        args: release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: gomodctl release
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@master
+
+    - name: Unshallow
+      run: git fetch --prune --unshallow
+
+    - name: Set up Go (1.13)
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@master
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split `build` and `release` actions.

Build action runs on each push to any branches.

Release action runs on each created tag and releases `gomodctl` using `GoReleaser`.