### PR TITLE
Imports and Importers in info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 [![gomodctl release](https://github.com/beatlabs/gomodctl/workflows/gomodctl%20release/badge.svg)](https://github.com/beatlabs/gomodctl/actions?query=workflow%3A%22gomodctl+release%22)
 [![gomodctl snyk](https://github.com/beatlabs/gomodctl/workflows/gomodctl%20snyk/badge.svg)](https://github.com/beatlabs/gomodctl/actions?query=workflow%3A%22gomodctl+snyk%22)
 
-*gomodctl* - search, check and update go modules.
+_gomodctl_ - search, check and update go modules.
 
 Currently supported commands:
-- search -  search for Go packages by the given term
+
+- search - search for Go packages by the given term
 - info - search by the given term and show information about the matched package
 - check - check project dependencies for the version information and shows outdated packages
 - update - automatically sync project dependencies with their latest version
@@ -27,7 +28,6 @@ Or using [Homebrew 🍺](https://brew.sh)
 brew tap beatlabs/gomodctl https://github.com/beatlabs/gomodctl
 brew install gomodctl
 ```
-
 
 ## Features
 
@@ -143,6 +143,8 @@ package trace
 ...
 ```
 
+Use `--imports` and `--importers` flags to see list of imports in the package or importers using the package.
+
 ### gomodctl check
 
 Check module versions in the given Go project.
@@ -183,6 +185,7 @@ gomodctl scan
 ```
 
 Result
+
 ```shell script
                 MODULE                | CONFIDENCE | SEVERITY |                       CWE                       |                                                                    LINE,COLUMN
 --------------------------------------+------------+----------+-------------------------------------------------+------------------------------------------------------------------------------------

--- a/internal/godoc/godoc.go
+++ b/internal/godoc/godoc.go
@@ -2,7 +2,6 @@ package godoc
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"github.com/beatlabs/gomodctl/internal"
@@ -110,17 +109,14 @@ func (c *Client) Imports(path string) ([]string, error) {
 		return nil, errors.New("path is empty")
 	}
 
-	resp, err := c.restClient.R().
+	imps := &imports{}
+	_, err := c.restClient.R().
 		SetContext(c.ctx).
 		SetHeader("Accept", "application/json").
+		SetResult(imps).
 		Get("https://api.godoc.org/imports/" + path)
 
 	if err != nil {
-		return nil, err
-	}
-
-	imps := &imports{}
-	if err := json.Unmarshal(resp.Body(), imps); err != nil {
 		return nil, err
 	}
 
@@ -137,17 +133,14 @@ func (c *Client) Importers(path string) ([]string, error) {
 		return nil, errors.New("path is empty")
 	}
 
-	resp, err := c.restClient.R().
+	imps := &importers{}
+	_, err := c.restClient.R().
 		SetContext(c.ctx).
 		SetHeader("Accept", "application/json").
+		SetResult(imps).
 		Get("https://api.godoc.org/importers/" + path)
 
 	if err != nil {
-		return nil, err
-	}
-
-	imps := &importers{}
-	if err := json.Unmarshal(resp.Body(), imps); err != nil {
 		return nil, err
 	}
 

--- a/internal/godoc/godoc_test.go
+++ b/internal/godoc/godoc_test.go
@@ -38,3 +38,21 @@ func TestClient_Info2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, response)
 }
+
+func TestClient_Imports(t *testing.T) {
+	client := NewClient(context.TODO())
+
+	response, err := client.Imports("github.com/stretchr/testify/mock")
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, response)
+}
+
+func TestClient_Importers(t *testing.T) {
+	client := NewClient(context.TODO())
+
+	response, err := client.Importers("github.com/stretchr/testify/mock")
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, response)
+}


### PR DESCRIPTION
Added go api calls to fetch imports and importers of matching package of info command

Added flags `--imports` and `--importers` to fetch and print imports and importers

Fixes #26 