### PR TITLE
goreleaser deprecated brew section updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: gomodctl release
-on: 
+on:
   push:
     tags:
       - "*"
@@ -12,18 +12,18 @@ jobs:
 
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
     - name: Unshallow
       run: git fetch --prune --unshallow
 
     - name: Set up Go (1.15)
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@master
+      uses: goreleaser/goreleaser-action@v2
       with:
         version: latest
         args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ release:
   draft: true
 brews:
  -
-  github:
+  tap:
     owner: beatlabs
     name: gomodctl
   description: "search,check and update go modules"

--- a/cmd/gomodctl/gomodctl.go
+++ b/cmd/gomodctl/gomodctl.go
@@ -24,6 +24,7 @@ import (
 )
 
 var ro RootOptions
+var version string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -36,6 +37,7 @@ Example:
   gomodctl search mongo
 
 This command will search in all public Go packages and return matching results for term "mongo".`,
+	Version: version,
 }
 
 // RootOptions is exported.


### PR DESCRIPTION
goreleaser deprecated `github` part in the configuration.
https://goreleaser.com/deprecations/#brewsgithub