### PR TITLE
Remove deprecated bottler option

### DIFF
--- a/Formula/gomodctl.rb
+++ b/Formula/gomodctl.rb
@@ -6,7 +6,6 @@ class Gomodctl < Formula
   desc "search,check and update go modules"
   homepage "https://github.com/beatlabs/gomodctl"
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/beatlabs/gomodctl/releases/download/v0.5.0/gomodctl_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
`:unneeded` no longer has any meaning to the bottler so should be safe to remove. I expect it won't return as `goreleaser` gets upgraded as well.

```
λ brew info gomodctl
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the beatlabs/gomodctl tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/beatlabs/homebrew-gomodctl/Formula/gomodctl.rb:9

beatlabs/gomodctl/gomodctl: stable 0.5.0
search,check and update go modules
https://github.com/beatlabs/gomodctl
/usr/local/Cellar/gomodctl/0.5.0 (5 files, 18.4MB) *
  Built from source on 2021-02-21 at 20:12:42
From: https://github.com/beatlabs/gomodctl/blob/HEAD/Formula/gomodctl.rb
```